### PR TITLE
core: Transition to PLAYING state after pending seek (Fixes #2005)

### DIFF
--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -153,7 +153,9 @@ class PlaybackController:
                     self.pause()
                     self._start_paused = False
             else:
-                self._seek(self._pending_position)
+                if self._seek(self._pending_position):
+                    self.set_state(PlaybackState.PLAYING)
+                    self._trigger_track_playback_started()
 
     def _on_position_changed(self, position):
         if self._pending_position is not None:


### PR DESCRIPTION
I'm not sure if if matters whether we change state before or after the seek. Both seem to work but I haven't really thought too much about it other that seeking first makes more sense to me.